### PR TITLE
Create user when login

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,11 +15,12 @@ jobs:
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           workingDirectory: './scripts/leaderboard'
-          preCommands: 'yarn install --frozen-lockfile'
-          secrets: |
-            SUPABASE_URL
-            SUPABASE_API_KEY
+          preCommands: |
+            yarn install --frozen-lockfile
+            echo $SUPABASE_URL | wrangler secret put SUPABASE_URL
+            echo $SUPABASE_ANON_KEY | wrangler secret put SUPABASE_ANON_KEY
+            echo "$SUPABASE_URL/graphql/v1" | wrangler secret put GRAPHQL_URI
         env:
           CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_API_KEY: ${{ secrets.SUPABASE_API_KEY }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}

--- a/scripts/leaderboard/.env.sample
+++ b/scripts/leaderboard/.env.sample
@@ -7,6 +7,6 @@
 DATABASE_URL="postgresql://postgres:pass@localhost:5432/postgres"
 
 SUPABASE_URL=https://example.supabase.co
-SUPABASE_API_KEY=sample
+SUPABASE_ANON_KEY=sample
 GRAPHQL_URI=http://example.com/graphql
-SUPABASE_ANON_KEY=key
+

--- a/scripts/leaderboard/app/graphql/mutations/signup.graphql
+++ b/scripts/leaderboard/app/graphql/mutations/signup.graphql
@@ -1,0 +1,12 @@
+mutation signup($email: String!, $name: String) {
+  insertIntoUserCollection(objects: [{
+    email: $email
+    name: $name
+  }]) {
+    records {
+      id
+      email
+      name
+    }
+  }
+}

--- a/scripts/leaderboard/app/graphql/request/Teaming.ts
+++ b/scripts/leaderboard/app/graphql/request/Teaming.ts
@@ -1,0 +1,26 @@
+import { client } from "../apollo-client";
+import {
+  SignupDocument,
+  SignupMutation,
+  SignupMutationVariables,
+} from "generated/graphql";
+import { ApolloError } from "@apollo/client";
+
+export const signup = async (variables: SignupMutationVariables) => {
+  try {
+    return await client.mutate<SignupMutation>({
+      mutation: SignupDocument,
+      variables,
+    });
+  } catch (e) {
+    if (e instanceof ApolloError) {
+      const msg = e.graphQLErrors[0];
+      if (isString(msg) && msg.includes("duplicate key")) return null;
+    }
+    console.error(e);
+
+    throw e;
+  }
+};
+
+const isString = (e: unknown): e is string => typeof e === "string";

--- a/scripts/leaderboard/app/graphql/schema/schema.graphql
+++ b/scripts/leaderboard/app/graphql/schema/schema.graphql
@@ -517,7 +517,7 @@ input StringFilter {
 type Team {
   id: Int!
   name: String
-  pageUrl: String!
+  pageUrl: String
   createdAt: Datetime!
   updatedAt: Datetime!
   measurementCollection(
@@ -669,7 +669,7 @@ input UUIDFilter {
 
 type User {
   id: Int!
-  teamId: Int!
+  teamId: Int
   email: String!
   name: String
   createdAt: Datetime!

--- a/scripts/leaderboard/app/libs/auth.server.ts
+++ b/scripts/leaderboard/app/libs/auth.server.ts
@@ -7,7 +7,7 @@ import { signup } from "~/graphql/request/Teaming";
 
 // for development
 export const skipAuth =
-  process.env.NODE_ENV === "development" && SUPABASE_API_KEY === "sample";
+  process.env.NODE_ENV === "development" && SUPABASE_ANON_KEY === "sample";
 
 export const sessionStorage = createCookieSessionStorage({
   cookie: {

--- a/scripts/leaderboard/app/libs/auth.server.ts
+++ b/scripts/leaderboard/app/libs/auth.server.ts
@@ -3,6 +3,7 @@ import { createCookieSessionStorage } from "@remix-run/cloudflare";
 import { SupabaseStrategy } from "@afaik/remix-auth-supabase-strategy";
 import { supabaseClient } from "~/libs/supabase.server";
 import type { Session } from "@supabase/supabase-js";
+import { signup } from "~/graphql/request/Teaming";
 
 // for development
 export const skipAuth =
@@ -32,9 +33,14 @@ export const supabaseStrategy = new SupabaseStrategy(
         refreshToken,
       });
 
-      if (error || !session) {
+      if (error || !session || !session.user?.email) {
         throw new AuthorizationError(error?.message ?? "No user session found");
       }
+
+      await signup({
+        email: session.user.email,
+        name: session.user.user_metadata.name ?? null,
+      });
 
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore

--- a/scripts/leaderboard/app/libs/supabase.server.ts
+++ b/scripts/leaderboard/app/libs/supabase.server.ts
@@ -1,5 +1,5 @@
-import { createClient } from "@supabase/supabase-js"
+import { createClient } from "@supabase/supabase-js";
 
-export const supabaseClient = createClient(SUPABASE_URL, SUPABASE_API_KEY, {
+export const supabaseClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
   fetch: fetch.bind(globalThis),
-})
+});

--- a/scripts/leaderboard/codegen.yml
+++ b/scripts/leaderboard/codegen.yml
@@ -1,6 +1,8 @@
 overwrite: true
 schema: "app/graphql/schema/schema.graphql"
-documents: "app/graphql/queries/**/*.graphql"
+documents:
+  - "app/graphql/queries/**/*.graphql"
+  - "app/graphql/mutations/**/*.graphql"
 generates:
   generated/graphql.tsx:
     plugins:

--- a/scripts/leaderboard/generated/graphql.schema.json
+++ b/scripts/leaderboard/generated/graphql.schema.json
@@ -3249,13 +3249,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -4191,13 +4187,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/scripts/leaderboard/generated/graphql.tsx
+++ b/scripts/leaderboard/generated/graphql.tsx
@@ -472,7 +472,7 @@ export type Team = {
   id: Scalars['Int'];
   measurementCollection?: Maybe<MeasurementConnection>;
   name?: Maybe<Scalars['String']>;
-  pageUrl: Scalars['String'];
+  pageUrl?: Maybe<Scalars['String']>;
   queueCollection?: Maybe<QueueConnection>;
   updatedAt: Scalars['Datetime'];
   userCollection?: Maybe<UserConnection>;
@@ -597,7 +597,7 @@ export type User = {
   id: Scalars['Int'];
   name?: Maybe<Scalars['String']>;
   team?: Maybe<Team>;
-  teamId: Scalars['Int'];
+  teamId?: Maybe<Scalars['Int']>;
   updatedAt: Scalars['Datetime'];
 };
 
@@ -763,12 +763,58 @@ export type _Prisma_MigrationsUpdateResponse = {
   records: Array<_Prisma_Migrations>;
 };
 
+export type SignupMutationVariables = Exact<{
+  email: Scalars['String'];
+  name?: InputMaybe<Scalars['String']>;
+}>;
+
+
+export type SignupMutation = { __typename?: 'Mutation', insertIntoUserCollection?: { __typename?: 'UserInsertResponse', records: Array<{ __typename?: 'User', id: number, email: string, name?: string | null }> } | null };
+
 export type SampleQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type SampleQuery = { __typename?: 'Query', queueCollection?: { __typename?: 'QueueConnection', edges: Array<{ __typename?: 'QueueEdge', node?: { __typename?: 'Queue', id: number } | null }> } | null };
 
 
+export const SignupDocument = gql`
+    mutation signup($email: String!, $name: String) {
+  insertIntoUserCollection(objects: [{email: $email, name: $name}]) {
+    records {
+      id
+      email
+      name
+    }
+  }
+}
+    `;
+export type SignupMutationFn = Apollo.MutationFunction<SignupMutation, SignupMutationVariables>;
+
+/**
+ * __useSignupMutation__
+ *
+ * To run a mutation, you first call `useSignupMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useSignupMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [signupMutation, { data, loading, error }] = useSignupMutation({
+ *   variables: {
+ *      email: // value for 'email'
+ *      name: // value for 'name'
+ *   },
+ * });
+ */
+export function useSignupMutation(baseOptions?: Apollo.MutationHookOptions<SignupMutation, SignupMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<SignupMutation, SignupMutationVariables>(SignupDocument, options);
+      }
+export type SignupMutationHookResult = ReturnType<typeof useSignupMutation>;
+export type SignupMutationResult = Apollo.MutationResult<SignupMutation>;
+export type SignupMutationOptions = Apollo.BaseMutationOptions<SignupMutation, SignupMutationVariables>;
 export const SampleDocument = gql`
     query sample {
   queueCollection {

--- a/scripts/leaderboard/generated/modules.d.ts
+++ b/scripts/leaderboard/generated/modules.d.ts
@@ -1,4 +1,13 @@
 
+declare module '*/signup.graphql' {
+  import { DocumentNode } from 'graphql';
+  const defaultDocument: DocumentNode;
+  export const signup: DocumentNode;
+
+  export default defaultDocument;
+}
+    
+
 declare module '*/sample.graphql' {
   import { DocumentNode } from 'graphql';
   const defaultDocument: DocumentNode;

--- a/scripts/leaderboard/global.d.ts
+++ b/scripts/leaderboard/global.d.ts
@@ -1,4 +1,3 @@
 declare const SUPABASE_URL: string;
-declare const SUPABASE_API_KEY: string;
 declare const GRAPHQL_URI: string;
 declare const SUPABASE_ANON_KEY: string;

--- a/scripts/leaderboard/prisma/migrations/20220407021426_/migration.sql
+++ b/scripts/leaderboard/prisma/migrations/20220407021426_/migration.sql
@@ -1,0 +1,8 @@
+-- DropForeignKey
+ALTER TABLE "User" DROP CONSTRAINT "User_teamId_fkey";
+
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "teamId" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "User" ADD CONSTRAINT "User_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/scripts/leaderboard/prisma/migrations/20220407024956_/migration.sql
+++ b/scripts/leaderboard/prisma/migrations/20220407024956_/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Team" ALTER COLUMN "pageUrl" DROP NOT NULL;

--- a/scripts/leaderboard/prisma/schema.prisma
+++ b/scripts/leaderboard/prisma/schema.prisma
@@ -13,7 +13,7 @@ datasource db {
 model Team {
   id        Int      @id @default(autoincrement())
   name      String?
-  pageUrl   String
+  pageUrl   String?
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now())
 
@@ -24,13 +24,13 @@ model Team {
 
 model User {
   id        Int      @id @default(autoincrement())
-  teamId    Int
+  teamId    Int?
   email     String   @unique
   name      String?
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now())
 
-  Team Team @relation(fields: [teamId], references: [id])
+  Team Team? @relation(fields: [teamId], references: [id])
 }
 
 model Measurement {

--- a/scripts/leaderboard/scripts/fetchGraphQLSchema.js
+++ b/scripts/leaderboard/scripts/fetchGraphQLSchema.js
@@ -3,6 +3,7 @@ const gradient = require("gradient-string");
 const path = require("path");
 const ProgressBar = require("progress");
 const { fetch } = require("cross-undici-fetch");
+require("dotenv").config();
 
 const {
   buildClientSchema,
@@ -46,7 +47,11 @@ function fetchGraphQLSchema(url, options) {
     });
 }
 
-const filePath = path.join(__dirname, "../app/graphql/schema/", "schema.graphql");
+const filePath = path.join(
+  __dirname,
+  "../app/graphql/schema/",
+  "schema.graphql"
+);
 
 console.log();
 


### PR DESCRIPTION
- ログイン(サインアップ)時にUserレコードを追加する
    - pg_graphqlにアップサートのミューテーションはなかったので、すでにサインアップ済み(Userレコード作成済み)でも、一旦ログイン時にミューテーションは投げて、`duplicate key`のエラーかどうかでハンドリングする
- github actionsのdeployがこけていたので修正
- SUPABASE_API_KEYとSUPABASE_ANON_KEYが同値だたため、SUPABASE_ANON_KEYに統一

---
以降別のPRで対応するること
- チーム作成機能
- チームの一覧表示
- チームジョイン機能