### PR TITLE
Create UserAndTeamContext and redirect when not joining any team

### DIFF
--- a/scripts/leaderboard/app/components/MeasurementReuestForm.tsx
+++ b/scripts/leaderboard/app/components/MeasurementReuestForm.tsx
@@ -4,14 +4,19 @@ import {
   Stack,
   FormControl,
   Input,
-  Button,
   useColorModeValue,
   Heading,
   Container,
   Flex,
 } from "@chakra-ui/react";
+import { PrimaryButton } from "~/components/atoms/Button";
 
-export const MeasurementRequestForm = () => {
+type Props = {
+  teamId: string;
+  url?: string;
+};
+
+export const MeasurementRequestForm = ({ teamId, url }: Props) => {
   // TODO: display error
   const errors = useActionData();
 
@@ -38,12 +43,7 @@ export const MeasurementRequestForm = () => {
           Request Measurement
         </Heading>
         <Form method="post">
-          {/* TODO: fetch and set teamID */}
-          <input
-            type="hidden"
-            value="eba2c0c1-6c2d-43f5-82f8-36ecb1410ce6"
-            name="termId"
-          />
+          <input type="hidden" value={teamId} name="termId" />
           <Stack direction={{ base: "column", md: "row" }} spacing="12px">
             <FormControl>
               <Input
@@ -57,12 +57,14 @@ export const MeasurementRequestForm = () => {
                 type="url"
                 required
                 placeholder="Your Page URL"
+                defaultValue={url ?? ""}
+                name="pageUrl"
               />
             </FormControl>
             <FormControl w={{ base: "100%", md: "40%" }}>
-              <Button colorScheme="blue" w="100%" type="submit">
+              <PrimaryButton w="full" type="submit">
                 Request
-              </Button>
+              </PrimaryButton>
             </FormControl>
           </Stack>
         </Form>

--- a/scripts/leaderboard/app/components/TeamCard.tsx
+++ b/scripts/leaderboard/app/components/TeamCard.tsx
@@ -13,7 +13,7 @@ import { PrimaryButton } from "~/components/atoms/Button";
 import { Form } from "@remix-run/react";
 
 type Props = {
-  id: number;
+  id: string;
   name: string;
   members: string[];
   joinable?: boolean;

--- a/scripts/leaderboard/app/components/contexts/UserAndTeam.tsx
+++ b/scripts/leaderboard/app/components/contexts/UserAndTeam.tsx
@@ -1,0 +1,33 @@
+import { createContext, ReactNode, useContext } from "react";
+import { User } from "@supabase/supabase-js";
+
+export type UserAndTeam = {
+  user: User | null;
+  team: {
+    id: string;
+    name?: string | null;
+    pageUrl?: string | null;
+  } | null;
+};
+
+const UserAndTeamContext = createContext<UserAndTeam>({
+  user: null,
+  team: null,
+});
+
+type Props = {
+  value: UserAndTeam;
+  children: ReactNode;
+};
+
+export const UserAndTeamContextProvider = (props: Props) => {
+  return <UserAndTeamContext.Provider {...props} />;
+};
+
+export const useUserContext = () => {
+  return useContext(UserAndTeamContext).user;
+};
+
+export const useTeamContext = () => {
+  return useContext(UserAndTeamContext).team;
+};

--- a/scripts/leaderboard/app/graphql/mutations/queue.graphql
+++ b/scripts/leaderboard/app/graphql/mutations/queue.graphql
@@ -1,8 +1,14 @@
-mutation lineup($teamId: UUID!) {
+mutation lineup($teamId: UUID!, $pageUrl: String!) {
   insertIntoQueueCollection(objects: [{teamId: $teamId, status: "RUNNING"}]) {
     records {
       id
       teamId
+    }
+  }
+  updateTeamCollection(filter: { id: { eq: $teamId } }, set: { pageUrl: $pageUrl }) {
+    records {
+      id
+      pageUrl
     }
   }
 }

--- a/scripts/leaderboard/app/graphql/queries/teams.graphql
+++ b/scripts/leaderboard/app/graphql/queries/teams.graphql
@@ -34,3 +34,17 @@ fragment teamsInfo on TeamConnection {
     }
   }
 }
+
+query myTeam ($email: String!) {
+  userCollection(filter: { email: { eq: $email } }, first: 1) {
+    edges {
+      node {
+        team {
+          id
+          name
+          pageUrl
+        }
+      }
+    }
+  }
+}

--- a/scripts/leaderboard/app/graphql/request/Teaming.ts
+++ b/scripts/leaderboard/app/graphql/request/Teaming.ts
@@ -10,6 +10,9 @@ import {
   ListTeamsPrevDocument,
   ListTeamsPrevQuery,
   ListTeamsQuery,
+  MyTeamDocument,
+  MyTeamQuery,
+  MyTeamQueryVariables,
   SignupDocument,
   SignupMutation,
   SignupMutationVariables,
@@ -75,4 +78,12 @@ export const listTeams = async (cursor: string | null, prev = false) => {
         cursor,
       },
     });
+};
+
+export const getMyTeam = async (variables: MyTeamQueryVariables) => {
+  const { data } = await client.query<MyTeamQuery>({
+    query: MyTeamDocument,
+    variables,
+  });
+  return data.userCollection?.edges[0].node?.team;
 };

--- a/scripts/leaderboard/app/libs/auth.server.ts
+++ b/scripts/leaderboard/app/libs/auth.server.ts
@@ -5,10 +5,6 @@ import { supabaseClient } from "~/libs/supabase.server";
 import type { Session } from "@supabase/supabase-js";
 import { signup } from "~/graphql/request/Teaming";
 
-// for development
-export const skipAuth =
-  process.env.NODE_ENV === "development" && SUPABASE_ANON_KEY === "sample";
-
 export const sessionStorage = createCookieSessionStorage({
   cookie: {
     name: "sb",

--- a/scripts/leaderboard/app/routes/dashboard/__layout.tsx
+++ b/scripts/leaderboard/app/routes/dashboard/__layout.tsx
@@ -1,35 +1,37 @@
-import { LoaderFunction } from "@remix-run/cloudflare";
-import { skipAuth, supabaseStrategy } from "~/libs/auth.server";
+import { LoaderFunction, redirect } from "@remix-run/cloudflare";
+import { supabaseStrategy } from "~/libs/auth.server";
 import { useLoaderData, Outlet } from "@remix-run/react";
 import { Box, Container } from "@chakra-ui/react";
 import { Navbar } from "~/components/Navbar";
-import { User } from "@supabase/supabase-js";
-
-type Data = {
-  user: User | null;
-};
+import { getMyTeam } from "~/graphql/request/Teaming";
+import {
+  UserAndTeam,
+  UserAndTeamContextProvider,
+} from "~/components/contexts/UserAndTeam";
 
 export const loader: LoaderFunction = async ({ request }) => {
-  if (skipAuth) return { user: null };
-
   const session = await supabaseStrategy.checkSession(request, {
     failureRedirect: "/auth/login",
   });
 
-  // TODO: redirect /dashboard/teams if user is not joined a team
+  const team = await getMyTeam({ email: session.user?.email ?? "" });
+  if (!team && new URL(request.url).pathname === "/dashboard")
+    return redirect("/dashboard/teams", { status: 302 });
 
-  return { user: session.user } as Data;
+  return { user: session.user, team } as UserAndTeam;
 };
 
 const Layout = () => {
-  const { user } = useLoaderData<Data>();
+  const data = useLoaderData<UserAndTeam>();
   return (
     <>
       <Box pos="fixed" w="100%" zIndex={10}>
-        <Navbar user={user} />
+        <Navbar user={data.user} />
       </Box>
       <Container maxW="8xl" pt={24}>
-        <Outlet />
+        <UserAndTeamContextProvider value={data}>
+          <Outlet />
+        </UserAndTeamContextProvider>
       </Container>
     </>
   );

--- a/scripts/leaderboard/app/routes/dashboard/__layout/index.tsx
+++ b/scripts/leaderboard/app/routes/dashboard/__layout/index.tsx
@@ -2,6 +2,7 @@ import { MeasurementRequestForm } from "~/components/MeasurementReuestForm";
 import { ActionFunction, LoaderFunction } from "@remix-run/cloudflare";
 import { getSample } from "~/graphql/request/Sample";
 import { lineup } from "~/graphql/request/Queue";
+import { useTeamContext } from "~/components/contexts/UserAndTeam";
 
 export const loader: LoaderFunction = async ({ request }) => {
   const test = await getSample();
@@ -12,17 +13,22 @@ export const loader: LoaderFunction = async ({ request }) => {
 
 export const action: ActionFunction = async ({ request }) => {
   const form = await request.formData();
+  const [teamId, pageUrl] = [form.get("termId"), form.get("pageUrl")];
+  if (!(typeof teamId === "string" && typeof pageUrl === "string"))
+    throw new Error("Invalid request");
 
-  // TODO: validation
-  const queues = await lineup({ teamId: form.get("termId") });
+  const queues = await lineup({ teamId, pageUrl });
 
   return queues?.data?.insertIntoQueueCollection?.records;
 };
 
 const Index = () => {
+  const team = useTeamContext();
+  if (!team) return null;
+
   return (
     <>
-      <MeasurementRequestForm />
+      <MeasurementRequestForm teamId={team.id} url={team.pageUrl ?? ""} />
     </>
   );
 };

--- a/scripts/leaderboard/generated/graphql.tsx
+++ b/scripts/leaderboard/generated/graphql.tsx
@@ -773,10 +773,11 @@ export type _Prisma_MigrationsUpdateResponse = {
 
 export type LineupMutationVariables = Exact<{
   teamId: Scalars['UUID'];
+  pageUrl: Scalars['String'];
 }>;
 
 
-export type LineupMutation = { __typename?: 'Mutation', insertIntoQueueCollection?: { __typename?: 'QueueInsertResponse', records: Array<{ __typename?: 'Queue', id: any, teamId: any }> } | null };
+export type LineupMutation = { __typename?: 'Mutation', insertIntoQueueCollection?: { __typename?: 'QueueInsertResponse', records: Array<{ __typename?: 'Queue', id: any, teamId: any }> } | null, updateTeamCollection: { __typename?: 'TeamUpdateResponse', records: Array<{ __typename?: 'Team', id: any, pageUrl?: string | null }> } };
 
 export type SignupMutationVariables = Exact<{
   email: Scalars['String'];
@@ -830,6 +831,13 @@ export type ListTeamsPrevQuery = { __typename?: 'Query', teamCollection?: { __ty
 
 export type TeamsInfoFragment = { __typename?: 'TeamConnection', pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null }, edges: Array<{ __typename?: 'TeamEdge', node?: { __typename?: 'Team', id: any, name?: string | null, pageUrl?: string | null, userCollection?: { __typename?: 'UserConnection', edges: Array<{ __typename?: 'UserEdge', node?: { __typename?: 'User', id: any, name?: string | null, email: string } | null }> } | null } | null }> };
 
+export type MyTeamQueryVariables = Exact<{
+  email: Scalars['String'];
+}>;
+
+
+export type MyTeamQuery = { __typename?: 'Query', userCollection?: { __typename?: 'UserConnection', edges: Array<{ __typename?: 'UserEdge', node?: { __typename?: 'User', team?: { __typename?: 'Team', id: any, name?: string | null, pageUrl?: string | null } | null } | null }> } | null };
+
 export const TeamsInfoFragmentDoc = gql`
     fragment teamsInfo on TeamConnection {
   pageInfo {
@@ -857,11 +865,17 @@ export const TeamsInfoFragmentDoc = gql`
 }
     `;
 export const LineupDocument = gql`
-    mutation lineup($teamId: UUID!) {
+    mutation lineup($teamId: UUID!, $pageUrl: String!) {
   insertIntoQueueCollection(objects: [{teamId: $teamId, status: "RUNNING"}]) {
     records {
       id
       teamId
+    }
+  }
+  updateTeamCollection(filter: {id: {eq: $teamId}}, set: {pageUrl: $pageUrl}) {
+    records {
+      id
+      pageUrl
     }
   }
 }
@@ -882,6 +896,7 @@ export type LineupMutationFn = Apollo.MutationFunction<LineupMutation, LineupMut
  * const [lineupMutation, { data, loading, error }] = useLineupMutation({
  *   variables: {
  *      teamId: // value for 'teamId'
+ *      pageUrl: // value for 'pageUrl'
  *   },
  * });
  */
@@ -1156,6 +1171,49 @@ export function useListTeamsPrevLazyQuery(baseOptions?: Apollo.LazyQueryHookOpti
 export type ListTeamsPrevQueryHookResult = ReturnType<typeof useListTeamsPrevQuery>;
 export type ListTeamsPrevLazyQueryHookResult = ReturnType<typeof useListTeamsPrevLazyQuery>;
 export type ListTeamsPrevQueryResult = Apollo.QueryResult<ListTeamsPrevQuery, ListTeamsPrevQueryVariables>;
+export const MyTeamDocument = gql`
+    query myTeam($email: String!) {
+  userCollection(filter: {email: {eq: $email}}, first: 1) {
+    edges {
+      node {
+        team {
+          id
+          name
+          pageUrl
+        }
+      }
+    }
+  }
+}
+    `;
+
+/**
+ * __useMyTeamQuery__
+ *
+ * To run a query within a React component, call `useMyTeamQuery` and pass it any options that fit your needs.
+ * When your component renders, `useMyTeamQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useMyTeamQuery({
+ *   variables: {
+ *      email: // value for 'email'
+ *   },
+ * });
+ */
+export function useMyTeamQuery(baseOptions: Apollo.QueryHookOptions<MyTeamQuery, MyTeamQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<MyTeamQuery, MyTeamQueryVariables>(MyTeamDocument, options);
+      }
+export function useMyTeamLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<MyTeamQuery, MyTeamQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<MyTeamQuery, MyTeamQueryVariables>(MyTeamDocument, options);
+        }
+export type MyTeamQueryHookResult = ReturnType<typeof useMyTeamQuery>;
+export type MyTeamLazyQueryHookResult = ReturnType<typeof useMyTeamLazyQuery>;
+export type MyTeamQueryResult = Apollo.QueryResult<MyTeamQuery, MyTeamQueryVariables>;
 
       export interface PossibleTypesResultData {
         possibleTypes: {

--- a/scripts/leaderboard/generated/modules.d.ts
+++ b/scripts/leaderboard/generated/modules.d.ts
@@ -43,6 +43,7 @@ declare module '*/teams.graphql' {
   export const listTeams: DocumentNode;
 export const listTeamsPrev: DocumentNode;
 export const teamsInfo: DocumentNode;
+export const myTeam: DocumentNode;
 
   export default defaultDocument;
 }


### PR DESCRIPTION
- チームに所属していない状態で/dashboardにアクセスしたら、/dashboard/teamsにリダイレクトさせる
- 自身と所属チームを取り扱うContext及びそのhooksを作成し、自身とチームの取得処理は__layoutに寄せて、配下のローダーに処理させないようにする
- キューを登録する際にチームのpageUrlを一緒にアップデートする
- その他雑多修正