### PR TITLE
Update tooltip label format

### DIFF
--- a/scripts/leaderboard/app/components/Chart.tsx
+++ b/scripts/leaderboard/app/components/Chart.tsx
@@ -25,11 +25,18 @@ export const Chart = ({ data }: Props) => {
         <XAxis
           dataKey="createdAt"
           domain={["dataMin", "dataMax"]}
-          tickFormatter={(unixTime) => new Date(unixTime).toLocaleString()}
+          tickFormatter={(unixTime) =>
+            new Date(unixTime).toLocaleString().slice(0, -3)
+          }
           type="number"
         />
         <YAxis dataKey="score" />
-        <Tooltip />
+        <Tooltip
+          labelStyle={{ color: "gray" }}
+          labelFormatter={(unixTime) =>
+            new Date(unixTime).toLocaleString().slice(0, -3)
+          }
+        />
         <Legend />
         {data.map(({ id, name, data }) => (
           <Line


### PR DESCRIPTION
もともと、x軸を時間軸にするために、unixTimeに変換してグラフに渡して、フォーマットで日時変換している。  
x軸のラベルは対応していたが、Tooltip内のデータに関してはフォーマットし忘れていたのでその対応。  
あと、秒まで表示するのは長いので、秒は省略