### PR TITLE
Refactor teams action by using remix-validated-form

### DIFF
--- a/scripts/leaderboard/app/components/NewTeamFormModal.tsx
+++ b/scripts/leaderboard/app/components/NewTeamFormModal.tsx
@@ -1,8 +1,5 @@
 import {
   Button,
-  FormControl,
-  FormLabel,
-  Input,
   Modal,
   ModalBody,
   ModalCloseButton,
@@ -12,8 +9,12 @@ import {
   ModalOverlay,
   useDisclosure,
 } from "@chakra-ui/react";
-import { Form } from "@remix-run/react";
 import { PrimaryButton } from "~/components/atoms/Button";
+import {
+  NewTeamFormWrapper,
+  Submit,
+  TeamNameInput,
+} from "~/components/forms/CreateTeam";
 
 export const NewTeamFormModal = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -27,26 +28,15 @@ export const NewTeamFormModal = () => {
         <ModalContent>
           <ModalHeader>Create new team</ModalHeader>
           <ModalCloseButton />
-          <Form method="post" onSubmit={onClose}>
+          <NewTeamFormWrapper>
             <ModalBody pb={6}>
-              <FormControl>
-                <FormLabel>* Team Name (max 15 chars)</FormLabel>
-                <Input required type="text" name="name" maxLength={15} />
-              </FormControl>
-
-              <FormControl mt={4}>
-                <FormLabel>URL</FormLabel>
-                <Input placeholder="Your page url" type="url" name="pageUrl" />
-              </FormControl>
+              <TeamNameInput />
             </ModalBody>
-
             <ModalFooter>
-              <PrimaryButton type="submit" mr={3}>
-                Save
-              </PrimaryButton>
+              <Submit afterSubmit={onClose} />
               <Button onClick={onClose}>Cancel</Button>
             </ModalFooter>
-          </Form>
+          </NewTeamFormWrapper>
         </ModalContent>
       </Modal>
     </>

--- a/scripts/leaderboard/app/components/TeamCard.tsx
+++ b/scripts/leaderboard/app/components/TeamCard.tsx
@@ -9,8 +9,7 @@ import {
   useColorModeValue,
 } from "@chakra-ui/react";
 import { BsFillPersonFill } from "react-icons/bs";
-import { PrimaryButton } from "~/components/atoms/Button";
-import { Form } from "@remix-run/react";
+import { JoinTeamForm } from "~/components/forms/JoinTeam";
 
 type Props = {
   id: string;
@@ -67,18 +66,7 @@ export const TeamCard = ({
             )}
           </List>
 
-          <Form method="post">
-            <input type="hidden" name="teamId" value={id} />
-            <PrimaryButton
-              mt={10}
-              w={"full"}
-              type="submit"
-              name="join"
-              disabled={!joinable || mine}
-            >
-              Join
-            </PrimaryButton>
-          </Form>
+          <JoinTeamForm teamId={id} disabled={!joinable || mine} />
         </Box>
       </Box>
     </Center>

--- a/scripts/leaderboard/app/components/forms/CreateTeam.tsx
+++ b/scripts/leaderboard/app/components/forms/CreateTeam.tsx
@@ -1,0 +1,68 @@
+import {
+  FormControl,
+  FormLabel,
+  Input,
+  FormErrorMessage,
+} from "@chakra-ui/react";
+import { PrimaryButton } from "~/components/atoms/Button";
+import { withZod } from "@remix-validated-form/with-zod";
+import { TeamModel } from "~/zod";
+import {
+  useField,
+  useFormContext,
+  useIsSubmitting,
+  validationError,
+  ValidatedForm,
+} from "remix-validated-form";
+import { createTeam } from "~/graphql/request/Teaming";
+import { ReactNode, useEffect } from "react";
+
+const validator = withZod(TeamModel.pick({ name: true }));
+
+export const handler = async (data: FormData) => {
+  if (!data.has("newTeam")) return;
+  const fieldValues = await validator.validate(data);
+  if (fieldValues.error) throw validationError(fieldValues.error);
+  const { name } = fieldValues.data;
+
+  await createTeam({ name });
+
+  return true;
+};
+
+export const NewTeamFormWrapper = ({ children }: { children: ReactNode }) => {
+  return (
+    <ValidatedForm method="post" validator={validator}>
+      {children}
+    </ValidatedForm>
+  );
+};
+
+export const TeamNameInput = () => {
+  const { error, getInputProps } = useField("name");
+  return (
+    <FormControl isInvalid={!!error}>
+      <FormLabel>Team Name</FormLabel>
+      <Input {...getInputProps()} />
+      {error && <FormErrorMessage>{error}</FormErrorMessage>}
+    </FormControl>
+  );
+};
+
+export const Submit = ({ afterSubmit }: { afterSubmit?: Function }) => {
+  const isSubmitting = useIsSubmitting();
+  const { isValid, hasBeenSubmitted } = useFormContext();
+  useEffect(() => {
+    hasBeenSubmitted && afterSubmit?.();
+  }, [hasBeenSubmitted, afterSubmit]);
+  return (
+    <PrimaryButton
+      type="submit"
+      mr={3}
+      disabled={isSubmitting || !isValid}
+      name="newTeam"
+    >
+      {isSubmitting ? "Submitting..." : "Submit"}
+    </PrimaryButton>
+  );
+};

--- a/scripts/leaderboard/app/components/forms/JoinTeam.tsx
+++ b/scripts/leaderboard/app/components/forms/JoinTeam.tsx
@@ -1,0 +1,56 @@
+import { PrimaryButton } from "~/components/atoms/Button";
+import { withZod } from "@remix-validated-form/with-zod";
+import { UserModel } from "~/zod";
+import {
+  useFormContext,
+  useIsSubmitting,
+  validationError,
+  ValidatedForm,
+} from "remix-validated-form";
+import { joinTeam } from "~/graphql/request/Teaming";
+import { useUserContext } from "~/components/contexts/UserAndTeam";
+
+const validator = withZod(UserModel.pick({ teamId: true, email: true }));
+
+export const handler = async (data: FormData) => {
+  if (!data.has("joinTeam")) return;
+  const fieldValues = await validator.validate(data);
+  if (fieldValues.error) throw validationError(fieldValues.error);
+  const { teamId, email } = fieldValues.data;
+
+  await joinTeam({ teamId, email });
+
+  return true;
+};
+
+export const JoinTeamForm = ({
+  teamId,
+  disabled = false,
+}: {
+  teamId: string;
+  disabled?: boolean;
+}) => {
+  return (
+    <ValidatedForm method="post" validator={validator}>
+      <input type="hidden" name="teamId" value={teamId} />
+      <input type="hidden" name="email" value={useUserContext()?.email ?? ""} />
+      <Submit disabled={disabled} />
+    </ValidatedForm>
+  );
+};
+
+const Submit = ({ disabled }: { disabled?: boolean }) => {
+  const isSubmitting = useIsSubmitting();
+  const { isValid } = useFormContext();
+  return (
+    <PrimaryButton
+      mt={10}
+      w={"full"}
+      type="submit"
+      name="joinTeam"
+      disabled={disabled || isSubmitting || !isValid}
+    >
+      {isSubmitting ? "Processing..." : "Join"}
+    </PrimaryButton>
+  );
+};

--- a/scripts/leaderboard/app/graphql/request/Teaming.ts
+++ b/scripts/leaderboard/app/graphql/request/Teaming.ts
@@ -92,6 +92,7 @@ export const listTeams = async (
   const { data } = await supabaseClient
     .from("Team")
     .select("id, name, pageUrl, users:User(email, name)")
+    .order("createdAt", { ascending: false })
     .range((page - 1) * 30, page * 30 - 1)
     .throwOnError();
 

--- a/scripts/leaderboard/app/zod/customs/index.ts
+++ b/scripts/leaderboard/app/zod/customs/index.ts
@@ -1,0 +1,1 @@
+export const strip = (val: string) => val.trim().length > 0;

--- a/scripts/leaderboard/app/zod/index.ts
+++ b/scripts/leaderboard/app/zod/index.ts
@@ -1,0 +1,4 @@
+export * from "./team"
+export * from "./user"
+export * from "./measurement"
+export * from "./queue"

--- a/scripts/leaderboard/app/zod/measurement.ts
+++ b/scripts/leaderboard/app/zod/measurement.ts
@@ -1,0 +1,25 @@
+import * as z from "zod"
+import * as imports from "./customs"
+import { CompleteTeam, RelatedTeamModel } from "./index"
+
+export const MeasurementModel = z.object({
+  id: z.string(),
+  teamId: z.string(),
+  score: z.number(),
+  vrtUrl: z.string(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+})
+
+export interface CompleteMeasurement extends z.infer<typeof MeasurementModel> {
+  Team: CompleteTeam
+}
+
+/**
+ * RelatedMeasurementModel contains all relations on your model in addition to the scalars
+ *
+ * NOTE: Lazy required in case of potential circular dependencies within schema
+ */
+export const RelatedMeasurementModel: z.ZodSchema<CompleteMeasurement> = z.lazy(() => MeasurementModel.extend({
+  Team: RelatedTeamModel,
+}))

--- a/scripts/leaderboard/app/zod/queue.ts
+++ b/scripts/leaderboard/app/zod/queue.ts
@@ -1,0 +1,32 @@
+import * as z from "zod"
+import * as imports from "./customs"
+import { QueueStatus } from "@prisma/client"
+import { CompleteTeam, RelatedTeamModel } from "./index"
+
+// Helper schema for JSON fields
+type Literal = boolean | number | string
+type Json = Literal | { [key: string]: Json } | Json[]
+const literalSchema = z.union([z.string(), z.number(), z.boolean()])
+const jsonSchema: z.ZodSchema<Json> = z.lazy(() => z.union([literalSchema, z.array(jsonSchema), z.record(jsonSchema)]))
+
+export const QueueModel = z.object({
+  id: z.string(),
+  teamId: z.string(),
+  status: z.nativeEnum(QueueStatus),
+  data: jsonSchema,
+  createdAt: z.date(),
+  updatedAt: z.date(),
+})
+
+export interface CompleteQueue extends z.infer<typeof QueueModel> {
+  Team: CompleteTeam
+}
+
+/**
+ * RelatedQueueModel contains all relations on your model in addition to the scalars
+ *
+ * NOTE: Lazy required in case of potential circular dependencies within schema
+ */
+export const RelatedQueueModel: z.ZodSchema<CompleteQueue> = z.lazy(() => QueueModel.extend({
+  Team: RelatedTeamModel,
+}))

--- a/scripts/leaderboard/app/zod/team.ts
+++ b/scripts/leaderboard/app/zod/team.ts
@@ -1,0 +1,28 @@
+import * as z from "zod"
+import * as imports from "./customs"
+import { CompleteUser, RelatedUserModel, CompleteMeasurement, RelatedMeasurementModel, CompleteQueue, RelatedQueueModel } from "./index"
+
+export const TeamModel = z.object({
+  id: z.string(),
+  name: z.string().min(3).max(15).refine(imports.strip),
+  pageUrl: z.string().nullish(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+})
+
+export interface CompleteTeam extends z.infer<typeof TeamModel> {
+  Users: CompleteUser[]
+  Measurements: CompleteMeasurement[]
+  Queues: CompleteQueue[]
+}
+
+/**
+ * RelatedTeamModel contains all relations on your model in addition to the scalars
+ *
+ * NOTE: Lazy required in case of potential circular dependencies within schema
+ */
+export const RelatedTeamModel: z.ZodSchema<CompleteTeam> = z.lazy(() => TeamModel.extend({
+  Users: RelatedUserModel.array(),
+  Measurements: RelatedMeasurementModel.array(),
+  Queues: RelatedQueueModel.array(),
+}))

--- a/scripts/leaderboard/app/zod/user.ts
+++ b/scripts/leaderboard/app/zod/user.ts
@@ -1,0 +1,25 @@
+import * as z from "zod"
+import * as imports from "./customs"
+import { CompleteTeam, RelatedTeamModel } from "./index"
+
+export const UserModel = z.object({
+  id: z.string(),
+  teamId: z.string().nullish(),
+  email: z.string().email(),
+  name: z.string().nullish(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+})
+
+export interface CompleteUser extends z.infer<typeof UserModel> {
+  Team?: CompleteTeam | null
+}
+
+/**
+ * RelatedUserModel contains all relations on your model in addition to the scalars
+ *
+ * NOTE: Lazy required in case of potential circular dependencies within schema
+ */
+export const RelatedUserModel: z.ZodSchema<CompleteUser> = z.lazy(() => UserModel.extend({
+  Team: RelatedTeamModel.nullish(),
+}))

--- a/scripts/leaderboard/package.json
+++ b/scripts/leaderboard/package.json
@@ -32,6 +32,7 @@
     "@remix-run/cloudflare": "^1.3.5",
     "@remix-run/cloudflare-workers": "^1.3.5",
     "@remix-run/react": "^1.3.5",
+    "@remix-validated-form/with-zod": "^2.0.1",
     "@supabase/supabase-js": "^1.33.3",
     "cross-env": "^7.0.3",
     "framer-motion": "^6.2.8",
@@ -43,7 +44,9 @@
     "recharts": "^2.1.9",
     "remix-auth": "^3.2.1",
     "remix-auth-supabase": "^3.1.0",
-    "remix-utils": "^3.0.0"
+    "remix-utils": "^3.0.0",
+    "remix-validated-form": "^4.3.0",
+    "zod": "^3.14.4"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^3.4.0",
@@ -60,13 +63,15 @@
     "@remix-run/eslint-config": "^1.3.5",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
+    "esbuild-plugin-alias": "^0.2.1",
     "eslint": "^8.11.0",
     "gradient-string": "^2.0.0",
     "miniflare": "^2.1.0",
     "npm-run-all": "^4.1.5",
     "remix-esbuild-override": "^3.0.2",
     "ts-node": "^10.7.0",
-    "typescript": "^4.5.5"
+    "typescript": "^4.5.5",
+    "zod-prisma": "^0.5.4"
   },
   "engines": {
     "node": ">=14"

--- a/scripts/leaderboard/prisma/migrations/20220412061801_/migration.sql
+++ b/scripts/leaderboard/prisma/migrations/20220412061801_/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `name` on table `Team` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "Team" ALTER COLUMN "name" SET NOT NULL;

--- a/scripts/leaderboard/prisma/schema.prisma
+++ b/scripts/leaderboard/prisma/schema.prisma
@@ -11,14 +11,14 @@ datasource db {
 }
 
 generator zod {
-  provider                 = "zod-prisma"
-  output                   = "../app/zod"
-  imports 		             = "../app/zod/customs"
-  relationModel            = true
-  modelCase                = "PascalCase"
-  modelSuffix              = "Model"
-  useDecimalJs             = true
-  prismaJsonNullability    = true
+  provider              = "zod-prisma"
+  output                = "../app/zod"
+  imports               = "../app/zod/customs"
+  relationModel         = true
+  modelCase             = "PascalCase"
+  modelSuffix           = "Model"
+  useDecimalJs          = true
+  prismaJsonNullability = true
 }
 
 model Team {
@@ -65,12 +65,12 @@ enum QueueStatus {
 }
 
 model Queue {
-  id     String      @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  teamId String      @db.Uuid
-  status QueueStatus @default(WAITING)
-  data   Json?
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now())
+  id        String      @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  teamId    String      @db.Uuid
+  status    QueueStatus @default(WAITING)
+  data      Json?
+  createdAt DateTime    @default(now())
+  updatedAt DateTime    @default(now())
 
   Team Team @relation(fields: [teamId], references: [id])
 }

--- a/scripts/leaderboard/prisma/schema.prisma
+++ b/scripts/leaderboard/prisma/schema.prisma
@@ -10,9 +10,21 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+generator zod {
+  provider                 = "zod-prisma"
+  output                   = "../app/zod"
+  imports 		             = "../app/zod/customs"
+  relationModel            = true
+  modelCase                = "PascalCase"
+  modelSuffix              = "Model"
+  useDecimalJs             = true
+  prismaJsonNullability    = true
+}
+
 model Team {
   id        String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  name      String?
+  /// @zod.min(3).max(15).refine(imports.strip)
+  name      String
   pageUrl   String?
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now())
@@ -25,6 +37,7 @@ model Team {
 model User {
   id        String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   teamId    String?  @db.Uuid
+  /// @zod.email()
   email     String   @unique
   name      String?
   createdAt DateTime @default(now())

--- a/scripts/leaderboard/remix.config.js
+++ b/scripts/leaderboard/remix.config.js
@@ -1,6 +1,7 @@
 const { withEsbuildOverride } = require("remix-esbuild-override");
 const GlobalsPolyfills =
   require("@esbuild-plugins/node-globals-polyfill").default;
+const alias = require("esbuild-plugin-alias");
 require("dotenv").config();
 
 withEsbuildOverride((option, { isServer }) => {
@@ -18,6 +19,9 @@ withEsbuildOverride((option, { isServer }) => {
     option.plugins = [
       GlobalsPolyfills({
         buffer: true,
+      }),
+      alias({
+        jotai: require.resolve("jotai"),
       }),
       ...option.plugins,
     ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2093,6 +2093,15 @@
   dependencies:
     "@prisma/engines-version" "3.12.0-37.22b822189f46ef0dc5c5b503368d1bee01213980"
 
+"@prisma/debug@3.8.1":
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-3.8.1.tgz#3c6717d6e0501651709714774ea6d90127c6a2d3"
+  integrity sha512-ft4VPTYME1UBJ7trfrBuF2w9jX1ipDy786T9fAEskNGb+y26gPDqz5fiEWc2kgHNeVdz/qTI/V3wXILRyEcgxQ==
+  dependencies:
+    "@types/debug" "4.1.7"
+    ms "2.1.3"
+    strip-ansi "6.0.1"
+
 "@prisma/engines-version@3.12.0-37.22b822189f46ef0dc5c5b503368d1bee01213980":
   version "3.12.0-37.22b822189f46ef0dc5c5b503368d1bee01213980"
   resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-3.12.0-37.22b822189f46ef0dc5c5b503368d1bee01213980.tgz#829ca3d9d0d92555f44644606d4edfd45b2f5886"
@@ -2102,6 +2111,16 @@
   version "3.11.1-1.1a2506facaf1a4727b7c26850735e88ec779dee9"
   resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-3.11.1-1.1a2506facaf1a4727b7c26850735e88ec779dee9.tgz#09ac23f8f615a8586d8d44538060ada199fe872c"
   integrity sha512-MILbsGnvmnhCbFGa2/iSnsyGyazU3afzD7ldjCIeLIGKkNBMSZgA2IvpYsAXl+6qFHKGrS3B2otKfV31dwMSQw==
+
+"@prisma/generator-helper@~3.8.1":
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-3.8.1.tgz#eb1dcc8382faa17c784a9d0e0d79fd207a222aa4"
+  integrity sha512-3zSy+XTEjmjLj6NO+/YPN1Cu7or3xA11TOoOnLRJ9G4pTT67RJXjK0L9Xy5n+3I0Xlb7xrWCgo8MvQQLMWzxPA==
+  dependencies:
+    "@prisma/debug" "3.8.1"
+    "@types/cross-spawn" "6.0.2"
+    chalk "4.1.2"
+    cross-spawn "7.0.3"
 
 "@reach/alert@0.13.2":
   version "0.13.2"
@@ -2233,6 +2252,11 @@
     set-cookie-parser "^2.4.8"
     source-map "^0.7.3"
 
+"@remix-validated-form/with-zod@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@remix-validated-form/with-zod/-/with-zod-2.0.1.tgz#83093578414b4fbf14841778b22facbd1e981ead"
+  integrity sha512-PerWFOeMFSd8FZRcT2kcqEnYEcmokBzuk87URZ5ij0cRtTlrGNUk7UlxYLG1e7lbPWBj+QfSSsLBrJu8PxhNeg==
+
 "@rollup/pluginutils@^4.0.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-4.2.0.tgz#a14bbd058fdbba0a5647143b16ed0d86fb60bd08"
@@ -2343,6 +2367,16 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
+"@ts-morph/common@~0.12.3":
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/@ts-morph/common/-/common-0.12.3.tgz#a96e250217cd30e480ab22ec6a0ebbe65fd784ff"
+  integrity sha512-4tUmeLyXJnJWvTFOKtcNJ1yh0a3SsTLi2MUoyj8iUNznFRN1ZquaNe7Oukqrnki2FzZkm0J9adCNLDZxUzvj+w==
+  dependencies:
+    fast-glob "^3.2.7"
+    minimatch "^3.0.4"
+    mkdirp "^1.0.4"
+    path-browserify "^1.0.1"
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
@@ -2395,6 +2429,13 @@
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
   integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
 
+"@types/cross-spawn@6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@types/cross-spawn/-/cross-spawn-6.0.2.tgz#168309de311cd30a2b8ae720de6475c2fbf33ac7"
+  integrity sha512-KuwNhp3eza+Rhu8IFI5HUXRP0LIhqH5cAjubUvGXXthh4YYBuP2ntwEX+Cz8GJoZUHlKo247wPWOfA9LYEq4cw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/d3-color@^2":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-2.0.3.tgz#8bc4589073c80e33d126345542f588056511fe82"
@@ -2431,7 +2472,7 @@
   resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-2.1.1.tgz#743fdc821c81f86537cbfece07093ac39b4bc342"
   integrity sha512-9MVYlmIgmRR31C5b4FVSWtuMmBHh2mOWQYfl7XAYOa8dsnb7iEmUmRSWSFgXFtkjxO65d7hTUHQC+RhR/9IWFg==
 
-"@types/debug@^4.0.0":
+"@types/debug@4.1.7", "@types/debug@^4.0.0":
   version "4.1.7"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
   integrity sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==
@@ -3902,6 +3943,13 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
+code-block-writer@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/code-block-writer/-/code-block-writer-11.0.0.tgz#5956fb186617f6740e2c3257757fea79315dd7d4"
+  integrity sha512-GEqWvEWWsOvER+g9keO4ohFoD3ymwyCnqY3hoTr7GZipYFwEhMHJw+TtV0rfgRhNImM6QWZGO2XYjlJVyYT62w==
+  dependencies:
+    tslib "2.3.1"
+
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
@@ -4919,6 +4967,11 @@ esbuild-openbsd-64@0.14.22:
   resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.22.tgz#2a73bba04e16d8ef278fbe2be85248e12a2f2cc2"
   integrity sha512-vK912As725haT313ANZZZN+0EysEEQXWC/+YE4rQvOQzLuxAQc2tjbzlAFREx3C8+uMuZj/q7E5gyVB7TzpcTA==
 
+esbuild-plugin-alias@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/esbuild-plugin-alias/-/esbuild-plugin-alias-0.2.1.tgz#45a86cb941e20e7c2bc68a2bea53562172494fcb"
+  integrity sha512-jyfL/pwPqaFXyKnj8lP8iLk6Z0m099uXR45aSN8Av1XD4vhvQutxxPzgA2bTcAwQpa1zCXDcWOlhFgyP3GKqhQ==
+
 esbuild-plugin-cache@^0.2.9:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/esbuild-plugin-cache/-/esbuild-plugin-cache-0.2.9.tgz#b4466b0803c8de9c21be4855e2dab1b99ee8eae2"
@@ -5494,7 +5547,7 @@ fast-equals@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-equals/-/fast-equals-2.0.4.tgz#3add9410585e2d7364c2deeb6a707beadb24b927"
   integrity sha512-caj/ZmjHljPrZtbzJ3kfH5ia/k4mTJe/qSiXAGzxZWRZgsgDV0cvNaQULqUX8t0/JVlzzEdYOwCN5DmzTxoD4w==
 
-fast-glob@3.2.11, fast-glob@^3.0.3, fast-glob@^3.2.9:
+fast-glob@3.2.11, fast-glob@^3.0.3, fast-glob@^3.2.7, fast-glob@^3.2.9:
   version "3.2.11"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
   integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
@@ -7125,6 +7178,11 @@ jake@^10.6.1:
     chalk "^2.4.2"
     filelist "^1.0.1"
     minimatch "^3.0.4"
+
+jotai@^1.5.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/jotai/-/jotai-1.6.3.tgz#225c278bf963400b2c29ff1e2fa4825dca488772"
+  integrity sha512-XwOZyHPwGdt7yQKM7EGHvXWF09LP/dGkEln+4tXgECNxKrmv9k7eFpzblNvO4G8xEusdj/qWhh2AlG+I0fC6mg==
 
 joycon@^3.0.0:
   version "3.1.0"
@@ -9060,6 +9118,11 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
+parenthesis@^3.1.8:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/parenthesis/-/parenthesis-3.1.8.tgz#3457fccb8f05db27572b841dad9d2630b912f125"
+  integrity sha512-KF/U8tk54BgQewkJPvB4s/US3VQY68BRDpH638+7O/n58TpnwiwnOtGIOsT2/i+M78s61BBpeC83STB88d8sqw==
+
 parse-cache-control@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parse-cache-control/-/parse-cache-control-1.0.1.tgz#8eeab3e54fa56920fe16ba38f77fa21aacc2d74e"
@@ -9135,6 +9198,11 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
+
+path-browserify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
+  integrity sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
 
 path-case@^3.0.4:
   version "3.0.4"
@@ -10136,6 +10204,15 @@ remix-utils@^3.0.0:
     type-fest "^2.5.2"
     uuid "^8.3.2"
 
+remix-validated-form@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/remix-validated-form/-/remix-validated-form-4.3.0.tgz#46e0adbdb2f297419d300837a500b69358b573c3"
+  integrity sha512-wNFHVFCsppk2tf2+j3BGzxm5TlfpzrHwRYaXZIskTaFrMLvpGSFNO5/AoFU2cKQNE1AabRapoNXPUxbHNkbEfQ==
+  dependencies:
+    jotai "^1.5.3"
+    lodash "^4.17.21"
+    tiny-invariant "^1.2.0"
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -10945,6 +11022,13 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
+strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
@@ -10958,13 +11042,6 @@ strip-ansi@^4.0.0:
   integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
   dependencies:
     ansi-regex "^3.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-bom@^2.0.0:
   version "2.0.0"
@@ -11201,7 +11278,7 @@ timed-out@4.0.1:
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
   integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
 
-tiny-invariant@^1.0.6:
+tiny-invariant@^1.0.6, tiny-invariant@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.2.0.tgz#a1141f86b672a9148c72e978a19a73b9b94a15a9"
   integrity sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==
@@ -11340,6 +11417,14 @@ ts-log@^2.2.3:
   resolved "https://registry.yarnpkg.com/ts-log/-/ts-log-2.2.4.tgz#d672cf904b33735eaba67a7395c93d45fba475b3"
   integrity sha512-DEQrfv6l7IvN2jlzc/VTdZJYsWUnQNCsueYjMkC/iXoEoi5fNan6MjeDqkvhfzbmHgdz9UxDUluX3V5HdjTydQ==
 
+ts-morph@^13.0.2:
+  version "13.0.3"
+  resolved "https://registry.yarnpkg.com/ts-morph/-/ts-morph-13.0.3.tgz#c0c51d1273ae2edb46d76f65161eb9d763444c1d"
+  integrity sha512-pSOfUMx8Ld/WUreoSzvMFQG5i9uEiWIsBYjpU9+TTASOeUa89j5HykomeqVULm1oqWtBdleI3KEFRLrlA3zGIw==
+  dependencies:
+    "@ts-morph/common" "~0.12.3"
+    code-block-writer "^11.0.0"
+
 ts-node@^10.7.0:
   version "10.7.0"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.7.0.tgz#35d503d0fab3e2baa672a0e94f4b40653c2463f5"
@@ -11381,15 +11466,15 @@ tsconfig-paths@^3.12.0, tsconfig-paths@^3.14.0, tsconfig-paths@^3.14.1:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
+tslib@2.3.1, tslib@^2, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@~2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
 tslib@^1.0.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^2, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@~2.3.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
-  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -12197,6 +12282,20 @@ zip-stream@^4.1.0:
     archiver-utils "^2.1.0"
     compress-commons "^4.1.0"
     readable-stream "^3.6.0"
+
+zod-prisma@^0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/zod-prisma/-/zod-prisma-0.5.4.tgz#f1c4d107cb9e4c666e2432017e6dcc390ef23700"
+  integrity sha512-5Ca4Qd1a1jy1T/NqCEpbr0c+EsbjJfJ/7euEHob3zDvtUK2rTuD1Rc/vfzH8q8PtaR2TZbysD88NHmrLwpv3Xg==
+  dependencies:
+    "@prisma/generator-helper" "~3.8.1"
+    parenthesis "^3.1.8"
+    ts-morph "^13.0.2"
+
+zod@^3.14.4:
+  version "3.14.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.14.4.tgz#e678fe9e5469f4663165a5c35c8f3dc66334a5d6"
+  integrity sha512-U9BFLb2GO34Sfo9IUYp0w3wJLlmcyGoMd75qU9yf+DrdGA4kEx6e+l9KOkAlyUO0PSQzZCa3TR4qVlcmwqSDuw==
 
 zwitch@^2.0.0:
   version "2.0.2"


### PR DESCRIPTION
- [remix-validated-form](https://github.com/airjp73/remix-validated-form)  と zodを利用して複雑化していたactionをリファクタ   
    - フォームコンポネントと同一ファイルに、バリデーションとサーバサイドのハンドラをもたせる
    - レンダリングするページのactionでハンドラを集約させることで、知識をページではなく各フォームに分散させる
- バリデーションはzod-prismaを利用し、スキーマ上にコメントアップすることで、複雑なバリデーション定義を書かなくて良いようにする