### PR TITLE
Update supabase key for RLS and limit signup email domain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,10 +23,12 @@ jobs:
             yarn install --frozen-lockfile
             echo $SUPABASE_URL | wrangler secret put SUPABASE_URL
             echo $SUPABASE_ANON_KEY | wrangler secret put SUPABASE_ANON_KEY
+            echo $SUPABASE_API_KEY | wrangler secret put SUPABASE_API_KEY
         env:
           CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          SUPABASE_API_KEY: ${{ secrets.SUPABASE_API_KEY }}
   deploy-measure:
     runs-on: ubuntu-latest
     steps:
@@ -49,5 +51,5 @@ jobs:
           service: web-speed-hackathon-2021-measure
           image: ${{ env.IMAGE }}
           region: ${{ env.GCP_REGION }}
-          env_vars: 'SUPABASE_URL="${{ secrets.SUPABASE_URL }}",SUPABASE_ANON_KEY="${{ secrets.SUPABASE_ANON_KEY }}",BUCKET_NAME="${{ secrets.BUCKET_NAME }}"'
+          env_vars: 'SUPABASE_URL="${{ secrets.SUPABASE_URL }}",SUPABASE_API_KEY="${{ secrets.SUPABASE_API_KEY }}",BUCKET_NAME="${{ secrets.BUCKET_NAME }}"'
           flags: "--memory=2Gi --concurrency=1"

--- a/scripts/leaderboard/.env.sample
+++ b/scripts/leaderboard/.env.sample
@@ -8,4 +8,5 @@ DATABASE_URL="postgresql://postgres:pass@localhost:5432/postgres"
 
 SUPABASE_URL=https://example.supabase.co
 SUPABASE_ANON_KEY=sample
-
+SUPABASE_API_KEY=secret
+ALLOWED_EMAIL_DOMAIN=

--- a/scripts/leaderboard/app/libs/auth.server.ts
+++ b/scripts/leaderboard/app/libs/auth.server.ts
@@ -33,6 +33,15 @@ export const supabaseStrategy = new SupabaseStrategy(
         throw new AuthorizationError(error?.message ?? "No user session found");
       }
 
+      if (
+        ALLOWED_EMAIL_DOMAIN &&
+        !session.user.email.endsWith(`@${ALLOWED_EMAIL_DOMAIN}`)
+      ) {
+        throw new AuthorizationError(
+          "You are an unauthorized organization user."
+        );
+      }
+
       await signup({
         email: session.user.email,
         name: session.user.user_metadata.name ?? null,

--- a/scripts/leaderboard/app/libs/supabase.server.ts
+++ b/scripts/leaderboard/app/libs/supabase.server.ts
@@ -1,5 +1,5 @@
 import { createClient } from "@supabase/supabase-js";
 
-export const supabaseClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+export const supabaseClient = createClient(SUPABASE_URL, SUPABASE_API_KEY, {
   fetch: fetch.bind(globalThis),
 });

--- a/scripts/leaderboard/global.d.ts
+++ b/scripts/leaderboard/global.d.ts
@@ -1,2 +1,3 @@
 declare const SUPABASE_URL: string;
-declare const SUPABASE_ANON_KEY: string;
+declare const SUPABASE_API_KEY: string;
+declare const ALLOWED_EMAIL_DOMAIN: string;

--- a/scripts/measure/src/database.ts
+++ b/scripts/measure/src/database.ts
@@ -1,32 +1,50 @@
 import { createClient } from "@supabase/supabase-js";
 
-const supabaseClient = createClient(process.env['SUPABASE_URL'] || '', process.env['SUPABASE_ANON_KEY'] || '');
+const supabaseClient = createClient(
+  process.env["SUPABASE_URL"] || "",
+  process.env["SUPABASE_API_KEY"] || ""
+);
 
 export const fetchTeamInfo = async (queueId: string) => {
-  const { data, error } = await supabaseClient.from<{Team: {id: string, pageUrl: string}}>('Queue').select('Team(id, pageUrl)').match({id: queueId});
+  const { data, error } = await supabaseClient
+    .from<{ Team: { id: string; pageUrl: string } }>("Queue")
+    .select("Team(id, pageUrl)")
+    .match({ id: queueId });
   if (error?.message) {
     console.error(error.message);
     throw new Error(error.message);
   } else if (data === null || !data[0]) {
-    throw new Error('not found Quere');
+    throw new Error("not found Quere");
   }
   return data[0].Team;
-}
+};
 
-export const updateQueueStatus = async (id: string, status: 'RUNNING' | 'FAILED' | 'DONE') => {
-  const { data, error } = await supabaseClient.from('Queue').update({status}).match({id});
+export const updateQueueStatus = async (
+  id: string,
+  status: "RUNNING" | "FAILED" | "DONE"
+) => {
+  const { data, error } = await supabaseClient
+    .from("Queue")
+    .update({ status })
+    .match({ id });
   if (error?.message) {
     console.error(error.message);
     throw new Error(error.message);
   }
   return data;
-}
+};
 
-export const createMeasurement = async (teamId: string, score: number, vrtUrl: string) => {
-  const { data, error } = await supabaseClient.from('Measurement').insert({teamId, score, vrtUrl});
+export const createMeasurement = async (
+  teamId: string,
+  score: number,
+  vrtUrl: string
+) => {
+  const { data, error } = await supabaseClient
+    .from("Measurement")
+    .insert({ teamId, score, vrtUrl });
   if (error?.message) {
     console.error(error.message);
     throw new Error(error.message);
   }
   return data;
-}
+};


### PR DESCRIPTION
- RLS の有効化
    - マイグレーションファイルを作成して自己発行したところ、RLSの有効化とポリシーの作成は行われたが、「serviceKeyによるオペレーションをバイパスする仕様」が無効化されてしまい、anonKey/serviceKeyによらずすべてのオペレーションが許可されなくなってしまった
    - web コンソール上でのオペレーションは、単に`ALTER TABLE tabele_name ENABEL ROW LEVEL SECURITY`が行われているだけでは無いようなので、自己発行は諦めてwebコンソールからRLSを有効化する
![スクリーンショット 2022-04-14 午前11 17 09](https://user-images.githubusercontent.com/6711766/163310320-69e2e2c6-4326-40e9-b330-0e08b37506c6.png)
- RLS有効化に当たり、ブラウザ側はANON_KEY, サーバ側はAPI_KEY(serviceKey)で通信するようにする
- サインアップ可能なドメインを環境変数で渡せるようにする