### PR TITLE
Fix supabaseClient for server and codenized RLS

### DIFF
--- a/scripts/leaderboard/app/libs/supabase.server.ts
+++ b/scripts/leaderboard/app/libs/supabase.server.ts
@@ -1,5 +1,16 @@
 import { createClient } from "@supabase/supabase-js";
 
 export const supabaseClient = createClient(SUPABASE_URL, SUPABASE_API_KEY, {
-  fetch: fetch.bind(globalThis),
+  fetch: (url, inits) => {
+    if (!url.toString().includes("/rest/v1")) return fetch(url, inits);
+    return fetch(url, {
+      ...inits,
+      ...(inits?.headers && {
+        headers: {
+          ...inits.headers,
+          Authorization: `Bearer ${SUPABASE_API_KEY}`,
+        },
+      }),
+    });
+  },
 });

--- a/scripts/leaderboard/prisma/migrations/20220414055100_/migration.sql
+++ b/scripts/leaderboard/prisma/migrations/20220414055100_/migration.sql
@@ -1,0 +1,10 @@
+-- This code was created manually.
+-- enable RLS
+ALTER TABLE "Team" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "User" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "Measurement" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "Queue" ENABLE ROW LEVEL SECURITY;
+
+-- public read anyone
+CREATE POLICY "Enable access to all users" ON "Measurement" FOR SELECT USING (true);
+CREATE POLICY "Enable access to all users" ON "Queue" FOR SELECT USING (true);


### PR DESCRIPTION
## RLSが障害につながっていた理由
### 前提
- supabaseのDBオペレーションはAuthorizationヘッダーのベアラトークンによって、current_userを切り替えており、RLSはそのユーザのロールが用いられる。
- 未認証状態では第2引数で渡されたキーがそのままAuthorizationヘッダーに入る
- supabaseClient.auth.signinをすると、以降はログインしたユーザのトークンがAuthorizationヘッダーにはいる

### 原因
なので、ログイン後はserviceKeyを使っていてもservice_roleではなく、一般ユーザ(authenticator)でDBオペレーションが行われるので、RLSを超えられない

### デバッグ中にミスリードした件
検証(デバッグ)では`supabaseClient.auth.signin`なしの状態で、手動作成したサンプルのテーブルに対してオペレーションを行っており、
それが原因で、「prismaから流したSQLではsupabaseのRLSが正しく設定されない」と勘違いした。

## 対策
- サーバサイドからののDBオペレーション(/rest/v1)に対してはAuthorizationを書き換えて、常にserviceKeyでのオペレーションに変える
    - /auth/v1などへもトークンの更新のためにリクエストが行われるので、上書きするのは/rest/v1のみに限定しないといけない