### PR TITLE
Enable moddatetime

### DIFF
--- a/scripts/leaderboard/prisma/migrations/20220414081100_/migration.sql
+++ b/scripts/leaderboard/prisma/migrations/20220414081100_/migration.sql
@@ -1,0 +1,13 @@
+-- This code was created manually.
+-- enable moddatetime
+create extension if not exists moddatetime schema extensions;
+
+-- create trigger
+create trigger handle_updated_at_Team before update on "Team"
+    for each row execute procedure moddatetime ("updatedAt");
+create trigger handle_updated_at_User before update on "User"
+    for each row execute procedure moddatetime ("updatedAt");
+create trigger handle_updated_at_Measurement before update on "Measurement"
+    for each row execute procedure moddatetime ("updatedAt");
+create trigger handle_updated_at_Queue before update on "Queue"
+    for each row execute procedure moddatetime ("updatedAt");


### PR DESCRIPTION
レコードをアップデートしたときに自動的にupdatedAtを更新するトリガ。

事前にこのトグルだけオンにしておく必要がある。(今後もしプロジェクトを作り変えることになったときのための知見として)  
それをしないとマイグレートがコケる
![スクリーンショット 2022-04-14 午後5 30 39](https://user-images.githubusercontent.com/6711766/163346298-6ceeb7ae-1556-4197-bdb9-c9ea40d30931.png)

