### PR TITLE
Update migrate file for extension moddatetime

### DIFF
--- a/scripts/leaderboard/prisma/migrations/20220414081100_/migration.sql
+++ b/scripts/leaderboard/prisma/migrations/20220414081100_/migration.sql
@@ -1,6 +1,6 @@
 -- This code was created manually.
 -- enable moddatetime
-create extension if not exists moddatetime schema extensions;
+create extension moddatetime;
 
 -- create trigger
 create trigger handle_updated_at_Team before update on "Team"


### PR DESCRIPTION
`if not exists`つけなければ、「webコンソールから事前にトグルをオンにする」ということはしなくてよかった。
あと、公式のドキュメントには、schemaの指定もないので削除する。  