### PR TITLE
Fix migrate for extensions and staging deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,9 +1,12 @@
-name: deploy
+name: production deploy
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows:
+      - staging deploy
+      - trigger for production
+    types:
+      - completed
 
 env:
   GCP_REGION: ${{ secrets.GCP_REGION }}
@@ -15,13 +18,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Install
+        working-directory: './scripts/leaderboard'
+        run: yarn install --frozen-lockfile
+      - name: Migrate
+        working-directory: './scripts/leaderboard'
+        run: yarn prisma migrate deploy
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
       - name: Publish
         uses: cloudflare/wrangler-action@next
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           workingDirectory: './scripts/leaderboard'
           preCommands: |
-            yarn install --frozen-lockfile
             echo $SUPABASE_URL | wrangler secret put SUPABASE_URL
             echo $SUPABASE_ANON_KEY | wrangler secret put SUPABASE_ANON_KEY
             echo $SUPABASE_API_KEY | wrangler secret put SUPABASE_API_KEY
@@ -37,25 +47,6 @@ jobs:
   deploy-measure:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout the repository
-        uses: actions/checkout@v2
-      - id: "auth"
-        uses: "google-github-actions/auth@v0"
-        with:
-          credentials_json: "${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}"
-      - name: Configure docker to use the gcloud cli
-        run: gcloud auth configure-docker --quiet
-      - name: Pull the docker image for cache
-        run: docker pull -q ${{ env.CACHE_CONTAINER_REGISTRY }}:cache | true
-      - name: Build a docker image
-        run: docker build --cache-from ${{ env.CACHE_CONTAINER_REGISTRY }}:cache -t ${{ env.IMAGE }} -f scripts/measure/Dockerfile .
-      - name: Tag a container image
-        run: docker tag ${{ env.IMAGE }} ${{ env.CACHE_CONTAINER_REGISTRY }}:cache
-      - name: Push the docker image
-        run: |
-          docker push ${{ env.IMAGE }} &
-          docker push ${{ env.CACHE_CONTAINER_REGISTRY }}:cache &
-          wait
       - name: Deploy to Cloud Run
         id: deploy
         uses: google-github-actions/deploy-cloudrun@v0

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,62 @@
+name: staging deploy
+
+on:
+  workflow_run:
+    workflows:
+      - image build
+    types:
+      - completed
+
+env:
+  GCP_REGION: ${{ secrets.GCP_REGION }}
+  IMAGE: asia.gcr.io/${{ secrets.GCP_PROJECT_ID }}/web-speed-hackathon-2021-measure:${{ github.sha }}
+  DATABASE_URL: ${{ secrets.DATABASE_URL_STAGING }}
+  SUPABASE_URL: ${{ secrets.SUPABASE_URL_STAGING }}
+  SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY_STAGING }}
+  SUPABASE_API_KEY: ${{ secrets.SUPABASE_API_KEY_STAGING }}
+  MEASURE_SERVER_URI: ${{ secrets.MEASURE_SERVER_URI_STAGING }}
+
+jobs:
+  deploy-frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install
+        working-directory: './scripts/leaderboard'
+        run: yarn install --frozen-lockfile
+      - name: Migrate
+        working-directory: './scripts/leaderboard'
+        run: yarn prisma migrate deploy
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      - name: Publish
+        uses: cloudflare/wrangler-action@next
+        with:
+          apiToken: ${{ secrets.CF_API_TOKEN }}
+          environment: staging
+          workingDirectory: './scripts/leaderboard'
+          preCommands: |
+            echo $SUPABASE_URL | wrangler secret put SUPABASE_URL
+            echo $SUPABASE_ANON_KEY | wrangler secret put SUPABASE_ANON_KEY
+            echo $SUPABASE_API_KEY | wrangler secret put SUPABASE_API_KEY
+            echo $ALLOWED_EMAIL_DOMAIN | wrangler secret put ALLOWED_EMAIL_DOMAIN
+            echo $MEASURE_SERVER_URI | wrangler secret put MEASURE_SERVER_URI
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          SUPABASE_API_KEY: ${{ secrets.SUPABASE_API_KEY }}
+          ALLOWED_EMAIL_DOMAIN: ${{ secrets.ALLOWED_EMAIL_DOMAIN }}
+          MEASURE_SERVER_URI: ${{ secrets.MEASURE_SERVER_URI }}
+  deploy-measure:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to Cloud Run
+        id: deploy
+        uses: google-github-actions/deploy-cloudrun@v0
+        with:
+          service: web-speed-hackathon-2021-measure-staging
+          image: ${{ env.IMAGE }}
+          region: ${{ env.GCP_REGION }}
+          env_vars: 'SUPABASE_URL=${{ secrets.SUPABASE_URL }},SUPABASE_API_KEY=${{ secrets.SUPABASE_API_KEY }},BUCKET_NAME=${{ secrets.BUCKET_NAME }}'
+          flags: "--allow-unauthenticated --memory=2Gi --concurrency=1"

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -1,0 +1,34 @@
+name: image build
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  CACHE_CONTAINER_REGISTRY: asia.gcr.io/${{ secrets.GCP_PROJECT_ID }}/web-speed-hackathon-2021-measure
+  IMAGE: asia.gcr.io/${{ secrets.GCP_PROJECT_ID }}/web-speed-hackathon-2021-measure:${{ github.sha }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - id: "auth"
+        uses: "google-github-actions/auth@v0"
+        with:
+          credentials_json: "${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}"
+      - name: Configure docker to use the gcloud cli
+        run: gcloud auth configure-docker --quiet
+      - name: Pull the docker image for cache
+        run: docker pull -q ${{ env.CACHE_CONTAINER_REGISTRY }}:cache | true
+      - name: Build a docker image
+        run: docker build --cache-from ${{ env.CACHE_CONTAINER_REGISTRY }}:cache -t ${{ env.IMAGE }} -f scripts/measure/Dockerfile .
+      - name: Tag a container image
+        run: docker tag ${{ env.IMAGE }} ${{ env.CACHE_CONTAINER_REGISTRY }}:cache
+      - name: Push the docker image
+        run: |
+          docker push ${{ env.IMAGE }} &
+          docker push ${{ env.CACHE_CONTAINER_REGISTRY }}:cache &
+          wait

--- a/.github/workflows/trigger-for-production.yml
+++ b/.github/workflows/trigger-for-production.yml
@@ -1,0 +1,10 @@
+name: trigger for production
+
+on:
+  workflow_dispatch:
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "fire the trigger for production"

--- a/scripts/leaderboard/prisma/migrations/20220414081100_/migration.sql
+++ b/scripts/leaderboard/prisma/migrations/20220414081100_/migration.sql
@@ -1,6 +1,8 @@
 -- This code was created manually.
 -- enable moddatetime
-create extension moddatetime;
+-- WARNING!!! Please pre-run this SQL from the supabase web console.
+-- This operation can only be performed by a super user.
+-- create extension moddatetime;
 
 -- create trigger
 create trigger handle_updated_at_Team before update on "Team"

--- a/scripts/leaderboard/wrangler.toml
+++ b/scripts/leaderboard/wrangler.toml
@@ -15,3 +15,6 @@ command = "npm run build"
 
 [build.upload]
 format="service-worker"
+
+[env.staging]
+name = "frontend-performance-contest-2022-staging"


### PR DESCRIPTION
- `create extension moddatetime;`はスーパユーザ(web コンソール)からのオペレーションのみしか許されていなかった
    - マイグレーションでの自動実行は諦め、ここだけは、web コンソールから事前に操作するようにする
- デプロイをstaging と production に分けるために、actionsも分割 & マイグレートも実行
    1. Measure用のイメージビルドのCI (main pushが条件)
    2. ステージングのfrontendデプロイとマイグレート &  measure デプロイ (1の成功が発動条件)
    3. 本番デプロイ用の手動トリガ (手動実行) 中身はechoしているだけ
    5. 本番のfrontendデプロイとマイグレート &  measure デプロイ (2と3の成功が条件)