### PR TITLE
Create the route to bypass standby page

### DIFF
--- a/scripts/leaderboard/app/libs/backdoor.server.ts
+++ b/scripts/leaderboard/app/libs/backdoor.server.ts
@@ -1,0 +1,10 @@
+import { createCookie } from "@remix-run/cloudflare";
+
+export const backdoorCookie = createCookie("backdoor", {
+  maxAge: 3600 * 24,
+  httpOnly: true,
+  path: "/",
+  sameSite: "lax",
+  secrets: ["s3cr3ts"],
+  secure: process.env.NODE_ENV === "production",
+});

--- a/scripts/leaderboard/app/routes/dashboard/__layout/backdoor.ts
+++ b/scripts/leaderboard/app/routes/dashboard/__layout/backdoor.ts
@@ -1,0 +1,14 @@
+import { LoaderFunction, redirect } from "@remix-run/cloudflare";
+import { backdoorCookie } from "~/libs/backdoor.server";
+
+export const loader: LoaderFunction = async ({ request }) => {
+  const cookie =
+    (await backdoorCookie.parse(request.headers.get("Cookie"))) ?? {};
+  cookie.nakanohito = "true";
+
+  return redirect("/dashboard", {
+    headers: {
+      "Set-Cookie": await backdoorCookie.serialize(cookie),
+    },
+  });
+};

--- a/scripts/leaderboard/app/routes/dashboard/__layout/index.tsx
+++ b/scripts/leaderboard/app/routes/dashboard/__layout/index.tsx
@@ -25,6 +25,7 @@ import { myQueues } from "~/request/Queue";
 import { supabaseStrategy } from "~/libs/auth.server";
 import { promiseHash } from "remix-utils";
 import { Statistics } from "~/components/Statistics";
+import { backdoorCookie } from "~/libs/backdoor.server";
 
 type Data = {
   scores: Awaited<ReturnType<typeof scoresForGraph>>;
@@ -33,7 +34,9 @@ type Data = {
 
 export const loader: LoaderFunction = async ({ request }) => {
   // TODO: remove
-  if (process.env.NODE_ENV === "production")
+  const cookie =
+    (await backdoorCookie.parse(request.headers.get("Cookie"))) ?? {};
+  if (process.env.NODE_ENV === "production" && !cookie.nakanohito)
     return redirect("/dashboard/standby");
 
   const session = await supabaseStrategy.checkSession(request);


### PR DESCRIPTION
本番当日までdashboardにアクセスできないので、中の人用ルートを作る。

単純に、/dashboard/backdoor にアクセスすると、cookieが付与されるというもの。  
このMRやminifest.jsonを見たら誰でもすぐに分かるようななんちゃって裏口だが、社内でやる分にはこのくらいで良いかと。